### PR TITLE
Add multiple cloud corrections for witch cloud combination

### DIFF
--- a/core/presentation/src/main/java/com/tobiashehrlein/tobiswizardblock/core/presentation/block/input/BlockInputViewModel.kt
+++ b/core/presentation/src/main/java/com/tobiashehrlein/tobiswizardblock/core/presentation/block/input/BlockInputViewModel.kt
@@ -19,6 +19,7 @@ abstract class BlockInputViewModel : BaseViewModelImpl(), BlockInputInteractions
     abstract val trumpType: LiveData<TrumpType>
     abstract val bombPlayed: LiveData<Boolean>
     abstract val cloudCardPlayed: LiveData<Boolean>
+    abstract val cloudCardCorrectionCount: LiveData<Int>
     abstract val playerTipDataCorrectedEvent: LiveData<PlayerTipData>
 
     abstract fun onInfoIconClicked()

--- a/core/presentation/src/main/java/com/tobiashehrlein/tobiswizardblock/core/presentation/block/input/BlockInputViewModelImpl.kt
+++ b/core/presentation/src/main/java/com/tobiashehrlein/tobiswizardblock/core/presentation/block/input/BlockInputViewModelImpl.kt
@@ -44,6 +44,7 @@ class BlockInputViewModelImpl(
     override val trumpType = MutableLiveData<TrumpType>()
     override val bombPlayed = MutableLiveData(DEFAULT_BOMB_PLAYED)
     override val cloudCardPlayed = MutableLiveData(DEFAULT_CLOUD_PLAYED)
+    override val cloudCardCorrectionCount = MutableLiveData(0)
     override val playerTipDataCorrectedEvent = MutableLiveData<PlayerTipData>()
     private val round = MutableLiveData<GameRound>()
 
@@ -62,9 +63,14 @@ class BlockInputViewModelImpl(
 
     private fun setInputModels(game: Game) {
         this.game.value = game
-        this.cloudCardPlayed.value = game.lastNonCompletedGameRound?.playerTipData
-            ?.sumOf { it.effectiveCloudCardCorrectionCount }
-            ?.let { it >= MAX_CLOUD_CARD_CORRECTIONS } == true
+        val cloudCardCorrectionCount = game.lastNonCompletedGameRound?.playerTipData
+            ?.sumOf { it.effectiveCloudCardCorrectionCount } ?: 0
+        val maximumCloudCardCorrections = minOf(
+            MAX_CLOUD_CARD_CORRECTIONS,
+            game.currentRoundNumber
+        )
+        this.cloudCardCorrectionCount.value = cloudCardCorrectionCount
+        this.cloudCardPlayed.value = cloudCardCorrectionCount >= maximumCloudCardCorrections
         this.trumpType.value = game.currentGameRound?.trumpType
         viewModelScope.launch {
             when (val result = getBlockInputModelsUseCase.invoke(game)) {

--- a/feature/block/src/main/java/com/tobiashehrlein/tobiswizardblock/feature/block/input/correcttips/BlockInputCorrectTipsChoosePlayerDialog.kt
+++ b/feature/block/src/main/java/com/tobiashehrlein/tobiswizardblock/feature/block/input/correcttips/BlockInputCorrectTipsChoosePlayerDialog.kt
@@ -214,7 +214,8 @@ class BlockInputCorrectTipsChoosePlayerDialog :
     }
 
     private fun checkButtons(initialTip: Int, updatedTip: Int) {
-        val availableCorrections = MAX_CLOUD_CARD_CORRECTIONS -
+        val maximumCorrections = minOf(MAX_CLOUD_CARD_CORRECTIONS, dialogEntity.round)
+        val availableCorrections = maximumCorrections -
             dialogEntity.playerTipData.sumOf { it.effectiveCloudCardCorrectionCount }
         val minimumTip = maxOf(0, initialTip - availableCorrections)
         val maximumTip = minOf(dialogEntity.round, initialTip + availableCorrections)

--- a/feature/block/src/main/res/layout/fragment_block_input.xml
+++ b/feature/block/src/main/res/layout/fragment_block_input.xml
@@ -74,7 +74,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/space_4"
-                        android:text="@string/block_input_anniversary_version_cloud_card_question"
+                        android:text="@{viewModel.cloudCardCorrectionCount > 0 ? @string/block_input_anniversary_version_second_cloud_card_question : @string/block_input_anniversary_version_cloud_card_question}"
                         android:textAppearance="?textAppearanceBody1"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"

--- a/feature/common/src/main/res/values-de/strings.xml
+++ b/feature/common/src/main/res/values-de/strings.xml
@@ -46,8 +46,8 @@
     <string name="game_rules_stitches_can_be_equal_bets_info">Wenn du dies aktivierst, können deine Tipps gleich der potenziell möglichen Stiche sein (z.B. Runde 2 = alle Tipps kombiniert dürfen 2 sein).\n\nFalls nicht, dürfen Tipps nicht gleich sein. Das bedeutet, dass der letzte Spieler ein Stich mehr oder weniger ansagen muss, sofern die angesagten Tipps zusammen gleich der potenziell möglichen Stiche ist.</string>
     <string name="game_rules_stitches_can_be_equal_in_first_round_text">Ausnahme: aktiviert für erste Runde</string>
     <string name="game_rules_stitches_can_be_equal_in_first_round_info">Wenn du dies aktivierst, ist die vorherige Regel für die erste Runde deaktiviert. Dies hat keinen Einfluss auf alle weiteren Runden.</string>
-    <string name="game_rules_anniversary_option_stitches_can_be_less">Erweitert: Jubiläumsversion</string>
-    <string name="game_rules_anniversary_option_stitches_can_be_less_info">Wenn du dies aktivierst, kannst du mit der Jubiläumsversion spielen. Das bedeuted, dass du weniger Stiche eingeben kannst, als potenziell möglich sind.\n\nIn der Jubiläumsversion gibt es mehr Karten (z.B. Drache, Bombe).</string>
+    <string name="game_rules_anniversary_option_stitches_can_be_less">30-Jahre-Edition</string>
+    <string name="game_rules_anniversary_option_stitches_can_be_less_info">Wenn du dies aktivierst, kannst du mit der 30-Jahre-Jubiläumsedition spielen. Das bedeuted, dass du weniger Stiche eingeben kannst, als potenziell möglich sind.\n\nIn der Jubiläumsversion gibt es mehr Karten (z. B. Drache, Bombe, Hexe).</string>
     <string name="game_rules_game_name_must_not_be_empty">Spielname darf nicht leer sein</string>
     <string name="game_rules_info_description">Das Spiel beginnt mit einer Karte und wird jede Runde um eine Karte bis zur Maximalanzahl erhöht. Wähle ein Spielname, um dieses Spiel eindeutig zu identifizieren. Anhand der Regeln kannst du ganz deinen Vorlieben spielen.</string>
 
@@ -78,6 +78,7 @@
     <string name="block_input_action_info_title">Info</string>
     <string name="block_input_action_trump_title">Trumpf</string>
     <string name="block_input_anniversary_version_cloud_card_question">Gibt es in dieser Runde einen Stich mit der Wolke?</string>
+    <string name="block_input_anniversary_version_second_cloud_card_question">Gibt es in dieser Runde einen zweiten Stich mit der Wolke?</string>
     <string name="block_input_anniversary_version_cloud_card_button">Tipps korrigieren</string>
     <string name="block_input_correct_bets_choose_player_title">Welcher Spieler muss sein Tipp korrigieren?</string>
     <string name="block_input_correct_bets_choose_player_name_and_bet">%1$s (%2$d)</string>

--- a/feature/common/src/main/res/values/strings.xml
+++ b/feature/common/src/main/res/values/strings.xml
@@ -59,8 +59,8 @@
         bets can not be equal to possible stitches. That means, the last player has to say one bet more or less, if all bets combined would be equal to possible stitches.</string>
     <string name="game_rules_stitches_can_be_equal_in_first_round_text">Exception: enable for first round</string>
     <string name="game_rules_stitches_can_be_equal_in_first_round_info">If enabled, previous rule is disabled for first round.\n\nThis does not affect all other rounds.</string>
-    <string name="game_rules_anniversary_option_stitches_can_be_less">Advanced: anniversary option</string>
-    <string name="game_rules_anniversary_option_stitches_can_be_less_info">If enabled, you can play with the anniversary version, which means, your stitches combined can be less than possible stitches.\n\nIn anniversary version, you have more cards than usual (e.g. dragon, bomb).</string>
+    <string name="game_rules_anniversary_option_stitches_can_be_less">30th Anniversary Edition</string>
+    <string name="game_rules_anniversary_option_stitches_can_be_less_info">If enabled, you can play with the 30th Anniversary Edition, which means, your stitches combined can be less than possible stitches.\n\nIn anniversary version, you have more cards than usual (e.g. dragon, bomb, witch).</string>
     <string name="game_rules_game_name_must_not_be_empty">Game name must not be empty</string>
     <string name="game_rules_info_description">The game starts with one card and is increased by one card each round up to the maximum number. Choose a game name to clearly identify this game. The rules allow you to play according to your preferences.</string>
 
@@ -94,6 +94,7 @@
     <string name="block_input_action_info_title">Info</string>
     <string name="block_input_action_trump_title">Trump</string>
     <string name="block_input_anniversary_version_cloud_card_question">Was there any stitch with the cloud card in this round?</string>
+    <string name="block_input_anniversary_version_second_cloud_card_question">Was there a second stitch with the cloud card in this round?</string>
     <string name="block_input_anniversary_version_cloud_card_button">Correct bets</string>
     <string name="block_input_correct_bets_choose_player_title">Which player must correct his/her bets?</string>
     <string name="block_input_correct_bets_choose_player_name_and_bet">%1$s (%2$d)</string>


### PR DESCRIPTION
I added the ability to make up to two cloud corrections and to undo each correction individually.
The reason for this is the recent release of the new witch special card, which allows a player to pick up a card and play it again. If the cloud card is picked up, it can trigger a correction twice in a single round.