### PR TITLE
Add multiple cloud correction for witch cloud combination

### DIFF
--- a/core/databaseroom/src/main/java/com/tobiashehrlein/tobiswizardblock/core/databaseroom/model/classes/DbPlayerTipData.kt
+++ b/core/databaseroom/src/main/java/com/tobiashehrlein/tobiswizardblock/core/databaseroom/model/classes/DbPlayerTipData.kt
@@ -3,5 +3,7 @@ package com.tobiashehrlein.tobiswizardblock.core.databaseroom.model.classes
 data class DbPlayerTipData(
     val playerName: String,
     val tip: Int,
-    val correctedCauseOfCloudCard: Boolean
+    val correctedCauseOfCloudCard: Boolean,
+    val cloudCardCorrectionCount: Int = 0,
+    val cloudCardCorrectionSteps: List<Int>? = null
 )

--- a/core/databaseroom/src/main/java/com/tobiashehrlein/tobiswizardblock/core/databaseroom/model/mapper/DbGameMapper.kt
+++ b/core/databaseroom/src/main/java/com/tobiashehrlein/tobiswizardblock/core/databaseroom/model/mapper/DbGameMapper.kt
@@ -64,13 +64,18 @@ fun DbGameRound.mapToEntity() = GameRound(
 fun PlayerTipData.mapToDbData() = DbPlayerTipData(
     playerName = playerName,
     tip = tip,
-    correctedCauseOfCloudCard = correctedCauseOfCloudCard
+    correctedCauseOfCloudCard = correctedCauseOfCloudCard,
+    cloudCardCorrectionCount = cloudCardCorrectionCount,
+    cloudCardCorrectionSteps = cloudCardCorrectionSteps
 )
 
 fun DbPlayerTipData.mapToEntity() = PlayerTipData(
     playerName = playerName,
     tip = tip,
-    correctedCauseOfCloudCard = correctedCauseOfCloudCard
+    correctedCauseOfCloudCard = correctedCauseOfCloudCard,
+    cloudCardCorrectionCount = cloudCardCorrectionCount.takeIf { it > 0 }
+        ?: if (correctedCauseOfCloudCard) 1 else 0,
+    cloudCardCorrectionSteps = cloudCardCorrectionSteps.orEmpty()
 )
 
 fun PlayerResultData.mapToDbData() = DbPlayerResultData(

--- a/core/entities/src/main/java/com/tobiashehrlein/tobiswizardblock/core/entities/game/general/PlayerTipData.kt
+++ b/core/entities/src/main/java/com/tobiashehrlein/tobiswizardblock/core/entities/game/general/PlayerTipData.kt
@@ -5,5 +5,15 @@ import java.io.Serializable
 data class PlayerTipData(
     val playerName: String,
     val tip: Int,
-    val correctedCauseOfCloudCard: Boolean = false
-) : Serializable
+    val correctedCauseOfCloudCard: Boolean = false,
+    val cloudCardCorrectionCount: Int = 0,
+    val cloudCardCorrectionSteps: List<Int> = emptyList()
+) : Serializable {
+
+    val effectiveCloudCardCorrectionCount: Int
+        get() = maxOf(
+            cloudCardCorrectionCount,
+            cloudCardCorrectionSteps.size,
+            if (correctedCauseOfCloudCard) 1 else 0
+        )
+}

--- a/core/entities/src/main/java/com/tobiashehrlein/tobiswizardblock/core/entities/game/input/InputDataItem.kt
+++ b/core/entities/src/main/java/com/tobiashehrlein/tobiswizardblock/core/entities/game/input/InputDataItem.kt
@@ -7,6 +7,8 @@ data class InputDataItem(
     val currentRound: Int,
     val cards: Int,
     val cloudCardPlayed: Boolean = false,
+    val cloudCardCorrectionCount: Int = 0,
+    val canUndoCloudCardCorrection: Boolean = false,
     val minInput: Int = 0,
     var userInput: Int = 0
 )

--- a/core/presentation/src/main/java/com/tobiashehrlein/tobiswizardblock/core/presentation/block/input/BlockInputInteractions.kt
+++ b/core/presentation/src/main/java/com/tobiashehrlein/tobiswizardblock/core/presentation/block/input/BlockInputInteractions.kt
@@ -5,4 +5,5 @@ import com.tobiashehrlein.tobiswizardblock.core.entities.game.input.InputDataIte
 interface BlockInputInteractions {
 
     fun onInputChanged(inputDataItem: InputDataItem)
+    fun onUndoTipCorrectionClicked(playerName: String)
 }

--- a/core/presentation/src/main/java/com/tobiashehrlein/tobiswizardblock/core/presentation/block/input/BlockInputViewModelImpl.kt
+++ b/core/presentation/src/main/java/com/tobiashehrlein/tobiswizardblock/core/presentation/block/input/BlockInputViewModelImpl.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.launch
 
 private const val DEFAULT_BOMB_PLAYED = false
 private const val DEFAULT_CLOUD_PLAYED = false
+private const val MAX_CLOUD_CARD_CORRECTIONS = 2
 
 class BlockInputViewModelImpl(
     private val gameId: Long,
@@ -61,9 +62,9 @@ class BlockInputViewModelImpl(
 
     private fun setInputModels(game: Game) {
         this.game.value = game
-        this.cloudCardPlayed.value = game.lastNonCompletedGameRound?.playerTipData?.any {
-            it.correctedCauseOfCloudCard
-        }
+        this.cloudCardPlayed.value = game.lastNonCompletedGameRound?.playerTipData
+            ?.sumOf { it.effectiveCloudCardCorrectionCount }
+            ?.let { it >= MAX_CLOUD_CARD_CORRECTIONS } == true
         this.trumpType.value = game.currentGameRound?.trumpType
         viewModelScope.launch {
             when (val result = getBlockInputModelsUseCase.invoke(game)) {
@@ -136,6 +137,37 @@ class BlockInputViewModelImpl(
 
     override fun correctPlayerTips(correctedPlayerTipData: List<PlayerTipData>) {
         val currentRound = round.value ?: error("could not determine round")
+        val oldPlayerTipData = currentRound.playerTipData
+        val correctPlayer = correctedPlayerTipData.firstOrNull { corrected ->
+            oldPlayerTipData?.firstOrNull { it.playerName == corrected.playerName && it.tip != corrected.tip } != null
+        } ?: error("no change detected")
+        storeCorrectedPlayerTips(correctedPlayerTipData, correctPlayer)
+    }
+
+    override fun onUndoTipCorrectionClicked(playerName: String) {
+        val currentRound = round.value ?: error("could not determine round")
+        val currentPlayerTipData = currentRound.playerTipData ?: error("no tips available")
+        val updatedPlayerTipData = currentPlayerTipData.map { playerTipData ->
+            if (playerTipData.playerName != playerName) return@map playerTipData
+
+            val correctionStep = playerTipData.cloudCardCorrectionSteps.lastOrNull()
+                ?: return@map playerTipData
+            val updatedCorrectionCount = playerTipData.effectiveCloudCardCorrectionCount - 1
+            playerTipData.copy(
+                tip = playerTipData.tip - correctionStep,
+                correctedCauseOfCloudCard = updatedCorrectionCount > 0,
+                cloudCardCorrectionCount = updatedCorrectionCount,
+                cloudCardCorrectionSteps = playerTipData.cloudCardCorrectionSteps.dropLast(1)
+            )
+        }
+        storeCorrectedPlayerTips(updatedPlayerTipData)
+    }
+
+    private fun storeCorrectedPlayerTips(
+        correctedPlayerTipData: List<PlayerTipData>,
+        correctedPlayer: PlayerTipData? = null
+    ) {
+        val currentRound = round.value ?: error("could not determine round")
         val round = InsertRoundData(
             gameId,
             currentRound.copy(
@@ -143,16 +175,11 @@ class BlockInputViewModelImpl(
             )
         )
 
-        val oldPlayerTipData = currentRound.playerTipData
-        val correctPlayer = correctedPlayerTipData.firstOrNull { corrected ->
-            oldPlayerTipData?.firstOrNull { it.playerName == corrected.playerName && it.tip != corrected.tip } != null
-        } ?: error("no change detected")
-
         viewModelScope.launch {
             when (val result = storeRoundUseCase.invoke(round)) {
                 is AppResult.Success -> {
                     getCurrentGame()
-                    playerTipDataCorrectedEvent.value = correctPlayer
+                    correctedPlayer?.let { playerTipDataCorrectedEvent.value = it }
                 }
                 is AppResult.Error -> Unit
             }

--- a/core/repositories/src/main/java/com/tobiashehrlein/tobiswizardblock/core/repositories/datasource/processor/BlockInputProcessorImpl.kt
+++ b/core/repositories/src/main/java/com/tobiashehrlein/tobiswizardblock/core/repositories/datasource/processor/BlockInputProcessorImpl.kt
@@ -92,6 +92,8 @@ class BlockInputProcessorImpl : BaseDatasource, BlockInputProcessor {
                     DEFAULT_MIN_INPUT
                 },
                 cloudCardPlayed = playerTipData?.correctedCauseOfCloudCard == true,
+                cloudCardCorrectionCount = playerTipData?.effectiveCloudCardCorrectionCount ?: 0,
+                canUndoCloudCardCorrection = playerTipData?.cloudCardCorrectionSteps?.isNotEmpty() == true,
                 userInput = getUserInput(
                     playerTipData,
                     game.gameInfo.gameSettings.anniversaryVersion

--- a/feature/block/src/main/java/com/tobiashehrlein/tobiswizardblock/feature/block/input/BlockInputAdapter.kt
+++ b/feature/block/src/main/java/com/tobiashehrlein/tobiswizardblock/feature/block/input/BlockInputAdapter.kt
@@ -44,6 +44,8 @@ object BockInputDiff : DiffUtil.ItemCallback<InputDataItem>() {
             oldItem.type == newItem.type &&
             oldItem.userInput == newItem.userInput &&
             oldItem.isDealer == newItem.isDealer &&
-            oldItem.cloudCardPlayed == newItem.cloudCardPlayed
+            oldItem.cloudCardPlayed == newItem.cloudCardPlayed &&
+            oldItem.cloudCardCorrectionCount == newItem.cloudCardCorrectionCount &&
+            oldItem.canUndoCloudCardCorrection == newItem.canUndoCloudCardCorrection
     }
 }

--- a/feature/block/src/main/java/com/tobiashehrlein/tobiswizardblock/feature/block/input/BlockInputViewHolder.kt
+++ b/feature/block/src/main/java/com/tobiashehrlein/tobiswizardblock/feature/block/input/BlockInputViewHolder.kt
@@ -52,6 +52,10 @@ class BlockInputViewHolder(private val binding: ItemBlockInputBinding) :
                 interactions.onInputChanged(inputDataItem)
             }
         }
+
+        binding.buttonUndoCloudCardCorrection.setOnClickListener {
+            interactions.onUndoTipCorrectionClicked(inputDataItem.player)
+        }
     }
 
     fun bindInputData(inputDataItem: InputDataItem) {
@@ -61,8 +65,13 @@ class BlockInputViewHolder(private val binding: ItemBlockInputBinding) :
 
         binding.buttonDecrease.isEnabled = inputDataItem.userInput > inputDataItem.minInput
         binding.buttonIncrease.isEnabled = inputDataItem.userInput != inputDataItem.currentRound
+        val cloudCardHint = if (inputDataItem.cloudCardCorrectionCount == 1) {
+            com.tobiashehrlein.tobiswizardblock.feature.common.R.string.block_input_anniversary_version_cloud_card_played_hint_singular
+        } else {
+            com.tobiashehrlein.tobiswizardblock.feature.common.R.string.block_input_anniversary_version_cloud_card_played_hint_plural
+        }
         binding.cloudCardPlayedHint.text = binding.root.context.getString(
-            com.tobiashehrlein.tobiswizardblock.feature.common.R.string.block_input_anniversary_version_cloud_card_played_hint,
+            cloudCardHint,
             inputDataItem.player
         )
     }

--- a/feature/block/src/main/java/com/tobiashehrlein/tobiswizardblock/feature/block/input/correcttips/BlockInputCorrectTipsChoosePlayerDialog.kt
+++ b/feature/block/src/main/java/com/tobiashehrlein/tobiswizardblock/feature/block/input/correcttips/BlockInputCorrectTipsChoosePlayerDialog.kt
@@ -18,10 +18,11 @@ import com.tobiashehrlein.tobiswizardblock.feature.common.ui.dialog.entity.Dialo
 import com.tobiashehrlein.tobiswizardblock.feature.common.ui.dialog.utils.DialogResultCode
 import com.tobiashehrlein.tobiswizardblock.feature.common.utils.extensions.getDimen
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import kotlin.math.abs
 
 private const val CHILD_RADIO_GROUP = 0
 private const val CHILD_COUNT = 1
-private const val ZERO_TIP = 0
+private const val MAX_CLOUD_CARD_CORRECTIONS = 2
 
 class BlockInputCorrectTipsChoosePlayerDialog :
     BaseDialogFragment<BlockInputCorrectTipsChoosePlayerViewModel, DialogBlockInputCorrectTipsChoosePlayerBinding>() {
@@ -136,10 +137,21 @@ class BlockInputCorrectTipsChoosePlayerDialog :
                     } else {
                         val selectedPlayerTipData = dialogEntity.playerTipData.first {
                             it.playerName.hashCode() == binding.blockInputCorrectTipsRadioGroup.checkedRadioButtonId
-                        }.copy(
-                            tip = binding.correctTipsLayout.seekBar.progress,
-                            correctedCauseOfCloudCard = true
-                        )
+                        }.let { selectedPlayerTipData ->
+                            val correctionDelta = binding.correctTipsLayout.seekBar.progress -
+                                selectedPlayerTipData.tip
+                            val correctionStep = if (correctionDelta > 0) 1 else -1
+                            selectedPlayerTipData.copy(
+                                tip = binding.correctTipsLayout.seekBar.progress,
+                                correctedCauseOfCloudCard = true,
+                                cloudCardCorrectionCount =
+                                    selectedPlayerTipData.effectiveCloudCardCorrectionCount +
+                                    abs(correctionDelta),
+                                cloudCardCorrectionSteps =
+                                    selectedPlayerTipData.cloudCardCorrectionSteps +
+                                    List(abs(correctionDelta)) { correctionStep }
+                            )
+                        }
 
                         val updatedPlayerTipData = dialogEntity.playerTipData.map {
                             if (it.playerName == selectedPlayerTipData.playerName) {
@@ -202,24 +214,13 @@ class BlockInputCorrectTipsChoosePlayerDialog :
     }
 
     private fun checkButtons(initialTip: Int, updatedTip: Int) {
-        when {
-            updatedTip < initialTip -> {
-                binding.correctTipsLayout.buttonDecrease.isEnabled = false
-                binding.correctTipsLayout.buttonIncrease.isEnabled = true
-                setPositiveButtonEnabled(true)
-            }
-            updatedTip > initialTip -> {
-                binding.correctTipsLayout.buttonDecrease.isEnabled = true
-                binding.correctTipsLayout.buttonIncrease.isEnabled = false
-                setPositiveButtonEnabled(true)
-            }
-            else -> {
-                val zeroTip = initialTip == ZERO_TIP
-                val maxTip = initialTip == dialogEntity.round
-                binding.correctTipsLayout.buttonDecrease.isEnabled = !zeroTip
-                binding.correctTipsLayout.buttonIncrease.isEnabled = !maxTip
-                setPositiveButtonEnabled(false)
-            }
-        }
+        val availableCorrections = MAX_CLOUD_CARD_CORRECTIONS -
+            dialogEntity.playerTipData.sumOf { it.effectiveCloudCardCorrectionCount }
+        val minimumTip = maxOf(0, initialTip - availableCorrections)
+        val maximumTip = minOf(dialogEntity.round, initialTip + availableCorrections)
+
+        binding.correctTipsLayout.buttonDecrease.isEnabled = updatedTip > minimumTip
+        binding.correctTipsLayout.buttonIncrease.isEnabled = updatedTip < maximumTip
+        setPositiveButtonEnabled(updatedTip != initialTip)
     }
 }

--- a/feature/block/src/main/res/layout-land/item_block_input.xml
+++ b/feature/block/src/main/res/layout-land/item_block_input.xml
@@ -96,10 +96,22 @@
             android:layout_marginTop="@dimen/space_2"
             android:textAppearance="?textAppearanceCaption"
             android:visibility="@{item.cloudCardPlayed}"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/button_undo_cloud_card_correction"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/button_decrease"
-            tools:text="@string/block_input_anniversary_version_cloud_card_played_hint" />
+            tools:text="@string/block_input_anniversary_version_cloud_card_played_hint_singular" />
+
+        <Button
+            android:id="@+id/button_undo_cloud_card_correction"
+            style="?borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="0dp"
+            android:text="@string/block_input_anniversary_version_cloud_card_undo"
+            android:visibility="@{item.canUndoCloudCardCorrection}"
+            app:layout_constraintBottom_toBottomOf="@id/cloud_card_played_hint"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/cloud_card_played_hint" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/feature/block/src/main/res/layout/item_block_input.xml
+++ b/feature/block/src/main/res/layout/item_block_input.xml
@@ -95,10 +95,22 @@
             android:layout_marginTop="@dimen/space_2"
             android:textAppearance="?textAppearanceCaption"
             android:visibility="@{item.cloudCardPlayed}"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/button_undo_cloud_card_correction"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/button_decrease"
-            tools:text="@string/block_input_anniversary_version_cloud_card_played_hint" />
+            tools:text="@string/block_input_anniversary_version_cloud_card_played_hint_singular" />
+
+        <Button
+            android:id="@+id/button_undo_cloud_card_correction"
+            style="?borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="0dp"
+            android:text="@string/block_input_anniversary_version_cloud_card_undo"
+            android:visibility="@{item.canUndoCloudCardCorrection}"
+            app:layout_constraintBottom_toBottomOf="@id/cloud_card_played_hint"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/cloud_card_played_hint" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/feature/common/src/main/res/values-de/strings.xml
+++ b/feature/common/src/main/res/values-de/strings.xml
@@ -81,12 +81,14 @@
     <string name="block_input_anniversary_version_cloud_card_button">Tipps korrigieren</string>
     <string name="block_input_correct_bets_choose_player_title">Welcher Spieler muss sein Tipp korrigieren?</string>
     <string name="block_input_correct_bets_choose_player_name_and_bet">%1$s (%2$d)</string>
-    <string name="block_input_correct_bets_count_title">Ein Stich mehr oder weniger ansagen %1$s?</string>
+    <string name="block_input_correct_bets_count_title">Wie viele Stiche mehr oder weniger möchte %1$s ansagen?</string>
     <string name="block_input_correct_bets_snackbar_message">Der Tipp von %1$s wurde auf %2$d korrigiert</string>
     <string name="block_input_anniversary_version_bomb_played">Wurde die Bombe gespielt?</string>
     <string name="block_input_anniversary_version_bomb_played_dialog_title">Bombe</string>
     <string name="block_input_anniversary_version_bomb_played_dialog_message">Wenn ein Spieler in dieser Runde die Bombe gespielt hat, wird der Stich beiseite gelegt und nicht gewertet. Das bedeutet, dass die Anzahl gemachter Stiche um 1 niedriger sein muss.</string>
-    <string name="block_input_anniversary_version_cloud_card_played_hint">%1$s hat seine/ihre Tipps anhand der Wolke verändert und muss dementsprechend mindestens 1 Stich gemacht haben.</string>
+    <string name="block_input_anniversary_version_cloud_card_played_hint_singular">%1$s hat den Tipp wegen der Wolke einmal korrigiert und muss mindestens 1 Stich gemacht haben.</string>
+    <string name="block_input_anniversary_version_cloud_card_played_hint_plural">%1$s hat den Tipp wegen der Wolke zweimal korrigiert und muss mindestens 1 Stich gemacht haben.</string>
+    <string name="block_input_anniversary_version_cloud_card_undo">Letzte Korrektur rückgängig</string>
 
     <!-- Block scores -->
     <string name="block_scores_toolbar_title">Aktueller Stand</string>

--- a/feature/common/src/main/res/values/strings.xml
+++ b/feature/common/src/main/res/values/strings.xml
@@ -97,12 +97,14 @@
     <string name="block_input_anniversary_version_cloud_card_button">Correct bets</string>
     <string name="block_input_correct_bets_choose_player_title">Which player must correct his/her bets?</string>
     <string name="block_input_correct_bets_choose_player_name_and_bet">%1$s (%2$d)</string>
-    <string name="block_input_correct_bets_count_title">Predict one stitch more or less %1$s?</string>
+    <string name="block_input_correct_bets_count_title">How many stitches more or less does %1$s want to predict?</string>
     <string name="block_input_correct_bets_snackbar_message">The bet of %1$s was corrected to %2$d</string>
     <string name="block_input_anniversary_version_bomb_played">Bomb was played?</string>
     <string name="block_input_anniversary_version_bomb_played_dialog_title">Bomb</string>
     <string name="block_input_anniversary_version_bomb_played_dialog_message">If someone played the bomb, the stitch will be put away and not evaluated. Therefore the amount of stitches must be 1 less.</string>
-    <string name="block_input_anniversary_version_cloud_card_played_hint">%1$s changed his/her bet because of the cloud card, so he/she must have made at least 1 stitch.</string>
+    <string name="block_input_anniversary_version_cloud_card_played_hint_singular">%1$s corrected the bet once because of the cloud card and must have made at least 1 stitch.</string>
+    <string name="block_input_anniversary_version_cloud_card_played_hint_plural">%1$s corrected the bet twice because of the cloud card and must have made at least 1 stitch.</string>
+    <string name="block_input_anniversary_version_cloud_card_undo">Undo last correction</string>
 
     <!-- Block scores -->
     <string name="block_scores_toolbar_title">Current Scores</string>


### PR DESCRIPTION
Steinente: Add tracking and undo for cloud-card tip corrections. Introduce cloudCardCorrectionCount and cloudCardCorrectionSteps in entity and DB models and an effectiveCloudCardCorrectionCount. Propagate fields to InputDataItem and repository mapping; add canUndoCloudCardCorrection. BlockInputViewModel adds MAX_CLOUD_CARD_CORRECTIONS (2), computes cloudCardPlayed from total corrections, supports applying and undoing corrections, and stores updated rounds. UI: adapter diff includes new fields, ViewHolder shows undo button and pluralized hint, layouts add undo button. Update EN/DE strings and dialog logic to record correction steps and limit corrections.